### PR TITLE
修复pgsql下迁移脚本的报错

### DIFF
--- a/nonebot_plugin_shindan/migrations/fdc15c338ecc_shindan_id_type.py
+++ b/nonebot_plugin_shindan/migrations/fdc15c338ecc_shindan_id_type.py
@@ -31,6 +31,7 @@ def upgrade(name: str = "") -> None:
             existing_type=sa.VARCHAR(length=32),
             type_=sa.Integer(),
             existing_nullable=False,
+            postgresql_using="shindan_id::integer",
         )
 
     # ### end Alembic commands ###


### PR DESCRIPTION
```
sqlalchemy.exc.ProgrammingError: : column "shindan_id" cannot be cast automatically to type integer
HINT:  You might need to specify "USING shindan_id::integer".
[SQL: ALTER TABLE nonebot_plugin_shindan_shindanrecord ALTER COLUMN shindan_id TYPE INTEGER ]
````